### PR TITLE
fixed bug to work with multiple spritemaps

### DIFF
--- a/svg-injector.js
+++ b/svg-injector.js
@@ -52,6 +52,8 @@
     var ranScripts;
     var config;
     var env;
+    
+    requestQueue = [];
 
     // - static vars ---------------------------------------------------
     SVGInjector.instanceCounter = 0;
@@ -77,7 +79,6 @@
         elements: []
       };
 
-      requestQueue = [];
       ranScripts = {};
       config = {};
 


### PR DESCRIPTION
moved requestQueue array initialization outside of init function to not override it, when more than one spritemaps are being initialized.
